### PR TITLE
added window_zoomed_flag to show_directory_in_window_status_current

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -101,7 +101,7 @@ main() {
 
   local show_directory_in_window_status_current
   #readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-  readonly show_directory_in_window_status_current="#[fg=colour232,bg=$thm_orange] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  readonly show_directory_in_window_status_current="#[fg=colour232,bg=$thm_orange] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) #[fg=$thm_orange,bg=colour237]#{?window_zoomed_flag,#(echo '⭘ '),}" 
 
   local show_window_in_window_status
   readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]$left_separator#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "


### PR DESCRIPTION
Felt like it happened very often that i missed the context of having a pane zoomed in. 
=> Added a unicode char (respecting active window colour palette) and showing IFF `window_zoomed_flag` is `1`

- 1) 
Might be better to add a whole new 
`show_directory_and_zoom_in_window_status_current`
to have a clean selection but could be an overcomplication.

- 2) 
Choice of unicode char was optimal on my screen/fontsize, should be easy enough to switch it for unicode supporting terminals.

Very unsure as if this PR process is ok by me and follows common etiquette, this would be my first PR ever. Apologies if I'm out of order.

![Screenshot_20230627_235232](https://github.com/dreamsofcode-io/catppuccin-tmux/assets/7521532/2d7f22d0-e0f7-4b21-adc4-9b08a0efa220)
