### PR TITLE
Fix left separator in window status

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -101,7 +101,7 @@ main() {
 
   local show_directory_in_window_status_current
   #readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-  readonly show_directory_in_window_status_current="#[fg=colour232,bg=$thm_orange] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  readonly show_directory_in_window_status_current="#[fg=colour232,bg=$thm_orange] #I#[fg=$thm_orange,bg=colour237]$left_separator#[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev)#[fg=colour237,bg=$thm_bg]$left_separator"
 
   local show_window_in_window_status
   readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]$left_separator#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "


### PR DESCRIPTION
Just a *super minor change*, fixing the separator on the left side of the tmux bar ;)

Thanks for the minimalist theme BTW, love it, not a big fan of the default clutter in the main theme.